### PR TITLE
Replace deprecated RulesProfile for scanner-side operations

### DIFF
--- a/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
+++ b/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
@@ -34,6 +34,7 @@ import org.codenarc.CodeNarcRunner;
 import org.codenarc.rule.Violation;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
@@ -52,11 +53,11 @@ public class CodeNarcSensor implements Sensor {
 
   private static final Logger LOG = Loggers.get(CodeNarcSensor.class);
 
-  private final RulesProfile rulesProfile;
+  private final ActiveRules activeRules;
   private final GroovyFileSystem groovyFileSystem;
 
-  public CodeNarcSensor(RulesProfile profile, GroovyFileSystem groovyFileSystem) {
-    this.rulesProfile = profile;
+  public CodeNarcSensor(ActiveRules activeRules, GroovyFileSystem groovyFileSystem) {
+    this.activeRules = activeRules;
     this.groovyFileSystem = groovyFileSystem;
   }
 
@@ -172,7 +173,7 @@ public class CodeNarcSensor implements Sensor {
   private void exportCodeNarcConfiguration(File file) {
     try {
       StringWriter writer = new StringWriter();
-      new CodeNarcProfileExporter(writer).exportProfile(rulesProfile);
+      new CodeNarcProfileExporter(writer).exportProfile(activeRules);
       FileUtils.writeStringToFile(file, writer.toString());
     } catch (IOException e) {
       throw new IllegalStateException("Can not generate CodeNarc configuration file", e);

--- a/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
+++ b/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -45,6 +46,8 @@ import org.mockito.quality.Strictness;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -52,7 +55,6 @@ import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.rules.ActiveRule;
 import org.sonar.plugins.groovy.GroovyPlugin;
 import org.sonar.plugins.groovy.foundation.Groovy;
 import org.sonar.plugins.groovy.foundation.GroovyFileSystem;
@@ -65,7 +67,7 @@ public class CodeNarcSensorTest {
   public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock
-  private RulesProfile profile;
+  private ActiveRules activeRules;
 
   private CodeNarcSensor sensor;
   private SensorContextTester sensorContextTester;
@@ -76,7 +78,7 @@ public class CodeNarcSensorTest {
     sensorContextTester.fileSystem().setWorkDir(temp.newFolder().toPath());
 
     sensorContextTester.setSettings(new MapSettings(new PropertyDefinitions(GroovyPlugin.class)));
-    sensor = new CodeNarcSensor(profile, new GroovyFileSystem(sensorContextTester.fileSystem()));
+    sensor = new CodeNarcSensor(activeRules, new GroovyFileSystem(sensorContextTester.fileSystem()));
   }
 
   @Test
@@ -167,8 +169,9 @@ public class CodeNarcSensorTest {
     sensorContextTester.setActiveRules(activeRulesBuilder.build());
 
     ActiveRule activeRule = mock(ActiveRule.class);
-    when(activeRule.getRuleKey()).thenReturn("org.codenarc.rule.basic.EmptyClassRule");
-    when(profile.getActiveRulesByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
+    when(activeRule.ruleKey()).thenReturn(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.basic.EmptyClassRule"));
+    when(activeRules.findByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY))
+        .thenReturn(Arrays.asList(activeRule));
 
     sensor.execute(sensorContextTester);
 
@@ -202,8 +205,8 @@ public class CodeNarcSensorTest {
     sensorContextTester.setActiveRules(activeRulesBuilder.build());
 
     ActiveRule activeRule = mock(ActiveRule.class);
-    when(activeRule.getRuleKey()).thenReturn("org.codenarc.rule.basic.EmptyClassRule");
-    when(profile.getActiveRulesByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
+    when(activeRule.ruleKey()).thenReturn(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.basic.EmptyClassRule"));
+    when(activeRules.findByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
 
     sensor.execute(sensorContextTester);
 


### PR DESCRIPTION
This should work in Sonarqube 7.6+

I'm a bit unsure about the validity of one of the tests, I left it Ignored for the moment to request advice.