### PR TITLE
Replace rules profile for SonarQube 7.5+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   </issueManagement>
 
   <properties>
-    <sonar.version>6.7</sonar.version>
+    <sonar.version>7.5</sonar.version>
     <jacoco.previous.version>0.7.4.201502262128</jacoco.previous.version>
     <jacoco.version>0.8.2</jacoco.version>
     <groovy.version>2.4.16</groovy.version>

--- a/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
+++ b/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
@@ -34,6 +34,7 @@ import org.codenarc.CodeNarcRunner;
 import org.codenarc.rule.Violation;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
@@ -52,11 +53,11 @@ public class CodeNarcSensor implements Sensor {
 
   private static final Logger LOG = Loggers.get(CodeNarcSensor.class);
 
-  private final RulesProfile rulesProfile;
+  private final ActiveRules activeRules;
   private final GroovyFileSystem groovyFileSystem;
 
-  public CodeNarcSensor(RulesProfile profile, GroovyFileSystem groovyFileSystem) {
-    this.rulesProfile = profile;
+  public CodeNarcSensor(ActiveRules activeRules, GroovyFileSystem groovyFileSystem) {
+    this.activeRules = activeRules;
     this.groovyFileSystem = groovyFileSystem;
   }
 
@@ -172,7 +173,7 @@ public class CodeNarcSensor implements Sensor {
   private void exportCodeNarcConfiguration(File file) {
     try {
       StringWriter writer = new StringWriter();
-      new CodeNarcProfileExporter(writer).exportProfile(rulesProfile);
+      new CodeNarcProfileExporter(writer).exportProfile(activeRules);
       FileUtils.writeStringToFile(file, writer.toString());
     } catch (IOException e) {
       throw new IllegalStateException("Can not generate CodeNarc configuration file", e);

--- a/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
+++ b/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
@@ -49,6 +49,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.ActiveRule;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
+import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.PropertyDefinitions;
@@ -247,8 +248,10 @@ public class CodeNarcSensorTest {
   }
 
   private static ActiveRulesBuilder activateRule(ActiveRulesBuilder activeRulesBuilder, String ruleKey, String internalKey) {
-    return activeRulesBuilder.create(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, ruleKey))
-        .setInternalKey(internalKey).activate();
+    return activeRulesBuilder.addRule(
+        new NewActiveRule.Builder().setRuleKey(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, ruleKey))
+        .setInternalKey(internalKey)
+        .build());
   }
 
 }

--- a/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
+++ b/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -45,6 +46,8 @@ import org.mockito.quality.Strictness;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -52,7 +55,6 @@ import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.rules.ActiveRule;
 import org.sonar.plugins.groovy.GroovyPlugin;
 import org.sonar.plugins.groovy.foundation.Groovy;
 import org.sonar.plugins.groovy.foundation.GroovyFileSystem;
@@ -65,7 +67,7 @@ public class CodeNarcSensorTest {
   public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock
-  private RulesProfile profile;
+  private ActiveRules activeRules;
 
   private CodeNarcSensor sensor;
   private SensorContextTester sensorContextTester;
@@ -76,7 +78,7 @@ public class CodeNarcSensorTest {
     sensorContextTester.fileSystem().setWorkDir(temp.newFolder().toPath());
 
     sensorContextTester.setSettings(new MapSettings(new PropertyDefinitions(GroovyPlugin.class)));
-    sensor = new CodeNarcSensor(profile, new GroovyFileSystem(sensorContextTester.fileSystem()));
+    sensor = new CodeNarcSensor(activeRules, new GroovyFileSystem(sensorContextTester.fileSystem()));
   }
 
   @Test
@@ -167,8 +169,9 @@ public class CodeNarcSensorTest {
     sensorContextTester.setActiveRules(activeRulesBuilder.build());
 
     ActiveRule activeRule = mock(ActiveRule.class);
-    when(activeRule.getRuleKey()).thenReturn("org.codenarc.rule.basic.EmptyClassRule");
-    when(profile.getActiveRulesByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
+    when(activeRule.ruleKey()).thenReturn(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.basic.EmptyClassRule"));
+    when(activeRules.findByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY))
+        .thenReturn(Arrays.asList(activeRule));
 
     sensor.execute(sensorContextTester);
 
@@ -202,8 +205,8 @@ public class CodeNarcSensorTest {
     sensorContextTester.setActiveRules(activeRulesBuilder.build());
 
     ActiveRule activeRule = mock(ActiveRule.class);
-    when(activeRule.getRuleKey()).thenReturn("org.codenarc.rule.basic.EmptyClassRule");
-    when(profile.getActiveRulesByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
+    when(activeRule.ruleKey()).thenReturn(RuleKey.of(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.basic.EmptyClassRule"));
+    when(activeRules.findByRepository(CodeNarcRulesDefinition.REPOSITORY_KEY)).thenReturn(Arrays.asList(activeRule));
 
     sensor.execute(sensorContextTester);
 


### PR DESCRIPTION
Since the testing API changed in 7.5, builds were failing.  Same changes as #4 otherwise