### PR TITLE
JaCoCoAnalyzer: log missing file only if extension is groovy

### DIFF
--- a/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoAnalyzer.java
+++ b/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoAnalyzer.java
@@ -81,7 +81,7 @@ public class JaCoCoAnalyzer {
     String path = getFileRelativePath(coverage);
     InputFile sourceInputFileFromRelativePath =
         groovyFileSystem.sourceInputFileFromRelativePath(path);
-    if (sourceInputFileFromRelativePath == null) {
+    if (sourceInputFileFromRelativePath == null && path.endsWith(".groovy")) {
       JaCoCoExtensions.logger().warn("File not found: " + path);
     }
     return sourceInputFileFromRelativePath;


### PR DESCRIPTION
cf. #30 