### PR TITLE
Updated woodstox-core version to 5.3.0

### DIFF
--- a/sonar-groovy-plugin/pom.xml
+++ b/sonar-groovy-plugin/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.fasterxml.woodstox</groupId>
       <artifactId>woodstox-core</artifactId>
-      <version>5.2.1</version>
+      <version>5.3.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Bumps woodstox-core from 5.2.1 to 6.2.7, revert to 5.3.0
[Bump woodstox-core from 5.2.1 to 6.2.7](https://github.com/Inform-Software/sonar-groovy/pull/98)
